### PR TITLE
fix three flaky tests in TopographyTest

### DIFF
--- a/h2gis-functions/src/test/java/org/h2gis/functions/spatial/topography/TopographyTest.java
+++ b/h2gis-functions/src/test/java/org/h2gis/functions/spatial/topography/TopographyTest.java
@@ -209,7 +209,7 @@ public class TopographyTest {
         try {
             st.execute("DROP TABLE IF EXISTS TIN");
             st.execute("CREATE TABLE TIN AS SELECT 'POLYGON ((-9.19 3.7 1, 0.3 1.41 4.4, -5.7 -4.15 4, -9.19 3.7 1))'::geometry the_geom");
-            ResultSet rs = st.executeQuery("select * from ST_TriangleContouring('TIN', 2,3,4,5)");
+            ResultSet rs = st.executeQuery("select * from ST_TriangleContouring('TIN', 2,3,4,5) order by idiso");
             assertEquals(2, rs.getMetaData().getColumnCount());
             assertTrue(rs.next());
             assertGeometryBarelyEquals("POLYGON ((-6.4 3.03 2, -9.19 3.7 1, -8.02 1.09 2, -6.4 3.03 2))", rs.getObject(1));
@@ -255,7 +255,7 @@ public class TopographyTest {
         try {
             st.execute("DROP TABLE IF EXISTS TIN");
             st.execute("CREATE TABLE TIN AS SELECT 'POLYGON ((-9.19 3.7 1, 0.3 1.41 4.4, -5.7 -4.15 4, -9.19 3.7 1))'::geometry the_geom, 1.0 as m1, 4.4 as m2, 4.0 as m3");
-            ResultSet rs = st.executeQuery("select * from ST_TriangleContouring('TIN','m1','m2','m3',2,3,4,5)");
+            ResultSet rs = st.executeQuery("select * from ST_TriangleContouring('TIN','m1','m2','m3',2,3,4,5) order by idiso");
             assertEquals(5, rs.getMetaData().getColumnCount());
             assertTrue(rs.next());
             assertGeometryBarelyEquals("POLYGON ((-6.4 3.03 2, -9.19 3.7 1, -8.02 1.09 2, -6.4 3.03 2))", rs.getObject(1));
@@ -300,7 +300,7 @@ public class TopographyTest {
         try {
             st.execute("DROP TABLE IF EXISTS TIN");
             st.execute("CREATE TABLE TIN AS SELECT 'POLYGON ((-9.19 3.7 1, 0.3 1.41 4.4, -5.7 -4.15 4, -9.19 3.7 1))'::geometry the_geom");
-            ResultSet rs = st.executeQuery("select * from ST_TriangleContouring('TIN', DOUBLERANGE(2,6,1))");
+            ResultSet rs = st.executeQuery("select * from ST_TriangleContouring('TIN', DOUBLERANGE(2,6,1)) order by idiso");
             assertEquals(2, rs.getMetaData().getColumnCount());
             assertTrue(rs.next());
             assertGeometryBarelyEquals("POLYGON ((-6.4 3.03 2, -9.19 3.7 1, -8.02 1.09 2, -6.4 3.03 2))", rs.getObject(1));


### PR DESCRIPTION
Several flaky tests are found in this project and this PR proposes to fix them.

1. How to reproduce the flaky tests
- The project is built and tested under `javaJDK8`.
- The tool used for the flaky test detection is [NonDex](https://github.com/TestingResearchIllinois/NonDex).
- I ran `mvn -pl h2gis-functions edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=org.h2gis.functions.spatial.topography.TopographyTest`, which produced
> [ERROR] Failures: 
> [ERROR]   TopographyTest.testST_TriangleContouringWithColumns:273 expected: <-6.86> but was: <-1.514117647058825>
> [ERROR]   TopographyTest.testST_TriangleContouringWithZ:215 expected: <-6.4> but was: <-1.514117647058825>
> [ERROR]   TopographyTest.testST_TriangleContouringWithZDoubleRange:318 expected: <-6.86> but was: <-1.514117647058825>

2. Why the tests failed
- The three tests fail for the same reason. The SQL query `select * from ST_TriangleContouring()` does not guarantee the order of the elements in the returned `ResultSet` since it doesn't have an `order by` clause.

3. The changes made
- `order by idiso` is added at the end of each query to sort the returned `ResultSet` to make the order predictable.